### PR TITLE
chore: Update checkout and node versions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           - openresty1.13
           - lua51
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Build Container
         run: docker-compose build ${{ matrix.variant }}
       - name: Lint


### PR DESCRIPTION
Update checkout and node versions to v4: https://hostingers.atlassian.net/browse/AUTO-3944